### PR TITLE
Small corrections to the Pod documentation

### DIFF
--- a/bin/proxy_that
+++ b/bin/proxy_that
@@ -13,7 +13,7 @@ App::ProxyThat->new->run;
 
 =head1 SYNOPSIS
 
-    ## Rnu a proxy to https://example.org on http://localhost:3080
+    ## Run a proxy to https://example.org on http://localhost:3080
     $ proxy_that https://example.org
 
     ## Proxy port 80 on your virtual machine to your local port 80

--- a/lib/App/ProxyThat.pm
+++ b/lib/App/ProxyThat.pm
@@ -98,6 +98,8 @@ sub _server_ready {
     
 =head1 DESCRIPTION
 
+See the L<proxy_that> command for an example of how to use this module.
+
 =head1 METHODS
 
 =head2 new


### PR DESCRIPTION
Fixed a spelling error and added a link to the `proxy_that` command.

_[[Assigned by [pullrequest.club](https://pullrequest.club/)]]_